### PR TITLE
Fix backward truefalse arguments in example.rb

### DIFF
--- a/example.rb
+++ b/example.rb
@@ -1,7 +1,7 @@
-# A quiz has a mandatory name and optional time limit in minutes.
+# A quiz has a mandatory name and optional duration (time limit) in seconds.
 # There's also various other obscure options not documented here.
 
-quiz 'Example quiz', :time_limit => 45 do
+quiz 'Example quiz', :duration => 2700 do
 
   # Examples of quiz questions.
   # All questions have an optional :points => n that determines the

--- a/html_template/template.html.erb
+++ b/html_template/template.html.erb
@@ -24,7 +24,7 @@
     <div class="instructions">
       <ul>
         <li>No books, notes, or electronic devices allowed.  </li>
-        <li>Time limit is 30 minutes.</li>
+        <li>Time limit is <%= duration / 60 %> minutes.</li>
         <li><%= num_questions %> multiple-choice questions, points indicated per question,
           <%= total_points %> points total.  Points per question are intended 
           to reflect approximate times they should take, at about 1 point per minute.</li>

--- a/lib/html5_renderer.rb
+++ b/lib/html5_renderer.rb
@@ -34,10 +34,11 @@ class Html5Renderer
   end
 
   def render_with_template
-    # 3 local variables that can should be in scope in the template:
+    # local variables that can be used in the template:
     title = @quiz.title
     total_points = @quiz.points
     num_questions = @quiz.num_questions
+    duration = @quiz.options[:duration]
     output = ERB.new(IO.read(File.expand_path @template)).result(binding)
     @output = output
   end

--- a/spec/html5_renderer_spec.rb
+++ b/spec/html5_renderer_spec.rb
@@ -51,10 +51,10 @@ describe Html5Renderer do
       return f.path
     end
     before :each do
-      @atts = {:title => 'My Quiz', :points => 20, :num_questions => 5} 
-      @quiz = mock('quiz', @atts.merge(:questions => []))
+      @atts = {:title => 'My Quiz', :points => 20, :num_questions => 5, :duration => 1200} 
+      @quiz = mock('quiz', @atts.merge(:questions => [], :options => {:duration => @atts[:duration]}))
     end
-    %w(title total_points num_questions).each do |var|
+    %w(title total_points num_questions duration).each do |var|
       it "should set '#{var}'" do
         value = @atts[var]
         Html5Renderer.new(@quiz, 't' => write_template("#{var}: <%= #{value} %>")).render_quiz.output.

--- a/spec/quiz_spec.rb
+++ b/spec/quiz_spec.rb
@@ -10,7 +10,7 @@ describe Quiz do
     Quiz.new('quiz',:questions => Array.new(3) { mock 'question', :points => 7 }).points.should == 21
   end
   describe 'should include required XML elements when XML renderer used' do
-    subject { Quiz.new('Foo', :maximum_submissions => 2, :start => '2011-01-01 00:00', :time_limit => 60).render_with(:xml) }
+    subject { Quiz.new('Foo', :maximum_submissions => 2, :start => '2011-01-01 00:00', :duration => 3600).render_with(:xml) }
     {'title' => 'Foo',
       'maximum_submissions' => '2',
       'type' => 'quiz' }.each_pair do |element, value|


### PR DESCRIPTION
The two `truefalse` examples in `example.rb` have the text and answer arguments backwards.

This might also suggest the need for validation of the answer argument for `truefalse` questions (should only accept a boolean?); let me know if you would find that helpful and I'll create a patch with code and spec.
