### PR TITLE
Fix broken spec from 153cda9 commit

### DIFF
--- a/spec/xml_renderer_spec.rb
+++ b/spec/xml_renderer_spec.rb
@@ -11,8 +11,9 @@ describe XmlRenderer do
   end
   describe 'calling renderers' do
     before(:each) do ; @x = XmlRenderer.new(:fake_quiz) ; end
-    it 'should call MultipleChoice renderer for multiple choice question' do
-      q = mock('multiple choice question', :class => 'MultipleChoice')
+    it 'should call MultipleChoice renderer for SelectMultiple question' do
+      q = SelectMultiple.new('question', :answers =>
+        [Answer.new('y1', true), Answer.new('n1', false), Answer.new('y2',true)])
       @x.should_receive(:render_multiple_choice).with(q)
       @x.render(q)
     end


### PR DESCRIPTION
The 153cda9 commit broke one of the specs; using a mock no longer
works with the new dispatch implementation (not sure why)? Changed
this spec to use SelectMultiple, since that appears to be the point
of the 153cda9 commit anyway.
