### PR TITLE
Fixing the explanations for truefalse questions

### DIFF
--- a/lib/true_false.rb
+++ b/lib/true_false.rb
@@ -1,11 +1,13 @@
 class TrueFalse < Question
 
-  def initialize(text, correct_answer, explanation=nil)
+  def initialize(text, correct_answer, opts=nil)
     super
+    opts ||= {}
+    opts[:explanation] ||= ''
     correct_answer = !!correct_answer # ensure 'true' or 'false' only
     self.question_text = "True or False: #{text}"
     self.answer correct_answer.to_s.capitalize
-    self.distractor (!correct_answer).to_s.capitalize, :explanation => explanation
+    self.distractor (!correct_answer).to_s.capitalize, :explanation => opts[:explanation]
   end
 
   def multiple ; false ; end


### PR DESCRIPTION
This fixes a bug that caused the xml renderer to crash. TrueFalse was being passed a hash of arguments instead of a string representing the explanation. I changed it to expect a hash of arguments and default the explanation to an empty string.
