### PR TITLE
Making the html5 template prettier when solutions are displayed

### DIFF
--- a/html_template/template.html.erb
+++ b/html_template/template.html.erb
@@ -12,6 +12,9 @@
     li.selectmultiple  ol.answers { vertical-align: center; list-style-type: none; list-style-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUAQMAAAC3R49OAAAABlBMVEUAAAD///+l2Z/dAAAAEklEQVQImWNgAIL6/w+ogoEAAKI4Kp2NVIeDAAAAAElFTkSuQmCC');  }
     li.truefalse ol.answers { list-style-type: none; }
     li.truefalse ol.answers li { width: 15%; display: inline-block; }
+    .correct { color: green }
+    .incorrect { color: red }
+    .explanation { font-style: italic }
     .instructions { clear: both; border: 1px solid black; align: center; padding: 2ex; margin: 2ex; }
     </style>
   </head>


### PR DESCRIPTION
Change some CSS to make the solutions easier to read. I realize that if the solutions are printed, the green/red might not come out well, but it's not going to detract from existing behavior.
