### PR TITLE
Fixes AutoQCM renderer and adds a Qualtrics renderer 

### DIFF
--- a/bin/ruql
+++ b/bin/ruql
@@ -16,6 +16,7 @@ renderer choices are:
   AutoQCM  - LaTeX for use with AutoQCM (http://home.gna.org/auto-qcm)
   Coursera - [obsolete] Coursera HTML/XML format for online auto-grading
   JSON     - [partially implemented] JSON format
+  Qualtrics -[partially implemented] Qualtrics survey (txt) format
 
 Global options:
   -l <loglevel>, --log=<loglevel>
@@ -64,6 +65,10 @@ The AutoQCM renderer supports these options:
 
 The JSON renderer currently supports no options
 
+The Qualtrics renderer supports these options:
+  -t <file.txt.erb>, --template=<file.txt.erb>
+  The file should have <%= yield %> where questions should go. Since this just creates survey questions, grading information is ignored.Currently supports the same type of questions as the AutoQCM renderer.
+
 eos
   exit
 end
@@ -80,7 +85,7 @@ def main
     ['-s', '--solutions', Getopt::BOOLEAN],
     ['-n', '--name', Getopt::REQUIRED],
     ['-l', '--log', Getopt::REQUIRED],
-    )
+    )    
   Quiz.instance_eval "#{IO.read(filename)}"
   Quiz.quizzes.each { |quiz| puts quiz.render_with(renderer, opts)  }
 end

--- a/lib/ruql.rb
+++ b/lib/ruql.rb
@@ -11,6 +11,7 @@ require 'ruql/renderers/html_form_renderer'
 require 'ruql/renderers/edxml_renderer'
 require 'ruql/renderers/auto_qcm_renderer'
 require 'ruql/renderers/json_renderer'
+require 'ruql/renderers/qualtrics_renderer'
 
 # question types
 require 'ruql/quiz'

--- a/lib/ruql/renderers/auto_qcm_renderer.rb
+++ b/lib/ruql/renderers/auto_qcm_renderer.rb
@@ -1,5 +1,6 @@
 require 'erb'
 require 'ruql/tex_output'
+require 'debugger'
 
 class AutoQCMRenderer
   include TexOutput
@@ -34,8 +35,8 @@ class AutoQCMRenderer
 
   def render_question(q,index)
     case q
+    when SelectMultiple,TrueFalse then render(q, index, 'mult') # These are subclasses of MultipleChoice, should go first
     when MultipleChoice then render(q, index)
-    when SelectMultiple,TrueFalse then render(q, index, 'mult')
     else
       @quiz.logger.error "Question #{index} (#{q.question_text[0,15]}...): AutoQCM can only handle multiple_choice, truefalse, or select_multiple questions"
       ''
@@ -48,7 +49,7 @@ class AutoQCMRenderer
     @output << "\\AMCrandomseed{#{seed}}\n\n"
   end
   
-  def render(question, index, type='')
+  def render(question, index, type='')    
     output = ''
     output << "\\begin{question#{type}}{q#{index}}\n"
     output << "  \\scoring{b=#{question.points},m=#{@penalty*question.points}}\n"
@@ -63,7 +64,7 @@ class AutoQCMRenderer
       output << "    \\#{answer_type}choice{#{answer_text}}\n"
     end
     output << "  \\end{choices}\n"
-    output << "\\end{question}\n\n"
+    output << "\\end{question#{type}}\n\n"
     output
   end
 

--- a/lib/ruql/renderers/qualtrics_renderer.rb
+++ b/lib/ruql/renderers/qualtrics_renderer.rb
@@ -1,0 +1,59 @@
+class QualtricsRenderer
+
+  attr_reader :output
+  
+  def initialize(quiz, options={})
+    @output = ''
+    @quiz = quiz
+    @template = options.delete('t') || options.delete('template')
+  end
+
+  def render_quiz
+    quiz = @quiz                # make quiz object available in template's scope
+    with_erb_template(IO.read(File.expand_path @template)) do
+      output = ''
+      @quiz.questions.each_with_index do |q,i|
+        next_question = render_question q,i
+        output << next_question
+      end
+      output
+    end
+  end
+
+  def with_erb_template(template)
+    # template will 'yield' back to render_quiz to render the questions
+    @output = ERB.new(template).result(binding)
+  end
+
+  def render_question(q,index)
+    case q
+    when SelectMultiple,TrueFalse then render(q, index, 'Multiple') # These are subclasses of MultipleChoice, should go first
+    when MultipleChoice then render(q, index, 'Single')
+    else
+      @quiz.logger.error "Question #{index} (#{q.question_text[0,15]}...): Only written to handle multiple_choice, truefalse, or select_multiple questions at this time."
+      ''
+    end
+  end
+  
+  def render(question, index, type='')    
+    output = ''
+    output << "[[Question:MC:#{type}Answer]]\n"
+    output << "[[ID:#{index}]]\n"
+    if type == 'Multiple'
+      question.question_text = "Select ALL that apply. " + question.question_text
+    elsif type == 'Single'
+      question.question_text = "Choose ONE answer. " + question.question_text
+    end
+    output << question.question_text << "\n"
+
+    # answers - ignore randomization
+
+    output << "[[AdvancedChoices]]\n"
+    question.answers.each do |answer|
+      output << "[[Choice]]\n"
+      output << "#{answer.answer_text}\n"
+    end
+    output
+  end
+
+end

--- a/lib/ruql/renderers/qualtrics_renderer.rb
+++ b/lib/ruql/renderers/qualtrics_renderer.rb
@@ -53,6 +53,10 @@ class QualtricsRenderer
       output << "[[Choice]]\n"
       output << "#{answer.answer_text}\n"
     end
+    if type == 'Multiple'
+      output << "[[Choice]]\n"
+      output << "<i>None of these answers are correct.</i>\n"
+    end
     output
   end
 

--- a/lib/ruql/tex_output.rb
+++ b/lib/ruql/tex_output.rb
@@ -1,15 +1,23 @@
 module TexOutput
 
+  def add_newlines(str)
+    str.gsub(Regexp.new('<pre>(.*?)</pre>', Regexp::MULTILINE | Regexp::IGNORECASE) ) do |code_section|
+      code_section.gsub!("\n"){"\\\\"}
+    end
+  end
+  
   @@tex_replace = {
     /_/ => '\textunderscore{}',
     Regexp.new('<tt>([^<]+)</tt>', Regexp::IGNORECASE) => "\\texttt{\\1}",
-    Regexp.new('<pre>(.*?)</pre>', Regexp::MULTILINE | Regexp::IGNORECASE) => "\\begin{Verbatim}\\1\\end{Verbatim}",
+    Regexp.new('<pre>(.*?)</pre>', Regexp::MULTILINE | Regexp::IGNORECASE) => "\\texttt{\\1}",
   }
 
   @@tex_escape = Regexp.new '\$|&|%|#|\{|\}'
 
   def to_tex(str)
     str = str.gsub(@@tex_escape) { |match| "\\#{match}" }
+    str = add_newlines(str)
+    
     @@tex_replace.each_pair do |match, replace|
       str = str.gsub(match, replace)
     end

--- a/lib/ruql/tex_output.rb
+++ b/lib/ruql/tex_output.rb
@@ -3,6 +3,7 @@ module TexOutput
   def add_newlines(str)
     str.gsub(Regexp.new('<pre>(.*?)</pre>', Regexp::MULTILINE | Regexp::IGNORECASE) ) do |code_section|
       code_section.gsub!("\n"){"\\\\"}
+      code_section.gsub!("  "){"\\hspace*{2em}"}      
     end
   end
   

--- a/ruql.gemspec
+++ b/ruql.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
                      tex_output).
     map { |s| "lib/ruql/#{s}.rb" }
   s.files += %w(auto_qcm_renderer edxml_renderer html5_renderer html_form_renderer
-                     json_renderer xml_renderer).
+                     json_renderer qualtrics_renderer xml_renderer).
     map { |s| "lib/ruql/renderers/#{s}.rb" }
   # add the templates
   s.files += Dir["templates/*.erb"]


### PR DESCRIPTION
Correctly generates LaTeX code for single/multiple choice answer questions, handles <pre>...</pre> sections by putting everything inside a \texttt{ ... } with line breaks instead of using Verbatim. Adds Qualtrics renderer to easily upload multiple choice questions to the Qualtrics platform. Allows for LaTeX solution files.